### PR TITLE
Check if opencv is installed to determine auto labels for 2D

### DIFF
--- a/src/napari_vector_graphics/_viewer.py
+++ b/src/napari_vector_graphics/_viewer.py
@@ -1,4 +1,5 @@
 import importlib
+import warnings
 from contextlib import nullcontext
 from typing import Literal
 
@@ -61,7 +62,17 @@ def viewer2svg(
             labels_mode = "raster"
 
     elif labels_mode == "auto":
-        labels_mode = "vector" if _OPENCV_INSTALLED else "raster"
+        if _OPENCV_INSTALLED:
+            labels_mode = "vector"
+        else:
+            warnings.warn(
+                "Labels Rendering Mode: Auto defaulted to Raster."
+                "'opencv' is required to convert labels as Vectors."
+                "You can install it with 'pip install opencv-python-headless'.",
+                category=UserWarning,
+                stacklevel=2,
+            )
+            labels_mode = "raster"
 
     with fit_canvas_to_content(viewer) if fit_content else nullcontext():
 

--- a/src/napari_vector_graphics/_viewer.py
+++ b/src/napari_vector_graphics/_viewer.py
@@ -66,7 +66,7 @@ def viewer2svg(
             labels_mode = "vector"
         else:
             warnings.warn(
-                "Labels Rendering Mode: Auto defaulted to Raster."
+                "Labels Rendering Mode: Auto defaulted from 'vector' to 'raster'."
                 "'opencv' is required to convert labels as Vectors."
                 "You can install it with 'pip install opencv-python-headless'.",
                 category=UserWarning,

--- a/src/napari_vector_graphics/_viewer.py
+++ b/src/napari_vector_graphics/_viewer.py
@@ -1,3 +1,4 @@
+import importlib
 from contextlib import nullcontext
 from typing import Literal
 
@@ -12,7 +13,7 @@ from napari_vector_graphics._tracks import tracks2svg
 from napari_vector_graphics._utils import fit_canvas_to_content
 
 _LABELS_MODES = ("auto", "raster", "vector")
-
+_OPENCV_INSTALLED = importlib.util.find_spec("cv2")
 
 def viewer2svg(
     viewer: napari.Viewer,
@@ -60,7 +61,7 @@ def viewer2svg(
             labels_mode = "raster"
 
     elif labels_mode == "auto":
-        labels_mode = "vector"
+        labels_mode = "vector" if _OPENCV_INSTALLED else "raster"
 
     with fit_canvas_to_content(viewer) if fit_content else nullcontext():
 


### PR DESCRIPTION
When testing #4, I noticed auto would use vector, despite not having `opencv-python-headless` installed. I have added a check to determine this and opted to emit a warning that it defaults to raster in this case. 

This builds on #4 because otherwise I can't test it on Windows. 